### PR TITLE
Include cohort/gene folder name in phenopacket entity IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The phenopacket-ingest pipeline processes phenopacket data through several steps
 This ingest relies on phenopacket data from the [phenopacket-store](https://github.com/monarch-initiative/phenopacket-store) repository, which contains structured phenotypic data about rare disease cases in the GA4GH Phenopacket format.
 
 ### Source Files
-- **phenopacket-store releases**: ZIP archive containing JSON phenopacket files organized by cohort
+- **phenopacket-store releases**: ZIP archive containing JSON phenopacket files organized by cohort (gene folder)
 - Each phenopacket contains standardized data about an individual case including:
   - Subject information (ID, sex, age)
   - Phenotypic features (HPO terms)
@@ -23,6 +23,24 @@ This ingest relies on phenopacket data from the [phenopacket-store](https://gith
   - Genetic findings (variants and genes)
   - Interpretations (causality assessments)
   - Metadata (references, provenance)
+
+### Entity ID Format
+
+Phenopacket Case entities are assigned IDs that include the cohort (gene folder) name for proper URI resolution:
+
+```
+phenopacket.store:{cohort}/{phenopacket_id}
+```
+
+For example:
+- `phenopacket.store:POGZ/PMID_34133408_case`
+- `phenopacket.store:KCNT1/PMID_30566666_patient1`
+- `phenopacket.store:11q_terminal_deletion/PMID_15266616_35`
+
+This format allows the Monarch API to expand the CURIE to the correct GitHub URL:
+```
+https://github.com/monarch-initiative/phenopacket-store/blob/main/notebooks/{cohort}/phenopackets/{phenopacket_id}.json
+```
 
 
 ## Requirements

--- a/src/phenopacket_ingest/transformer/phenopacket_transformer.py
+++ b/src/phenopacket_ingest/transformer/phenopacket_transformer.py
@@ -105,8 +105,15 @@ class PhenopacketTransformer:
         if record.subject.sex:
             biological_sex = str(record.subject.sex.value)
 
+        # Include cohort in ID for proper URI resolution (see issue #6)
+        # Format: phenopacket.store:{cohort}/{id}
+        if record.cohort:
+            case_id = f"phenopacket.store:{record.cohort}/{record.id}"
+        else:
+            case_id = f"phenopacket.store:{record.id}"
+
         case = Case(
-            id=f"phenopacket.store:{record.id}",
+            id=case_id,
             name=record.subject.id,
             has_biological_sex=biological_sex,
         )


### PR DESCRIPTION
## Summary

- Modifies Case entity IDs to include the cohort (gene folder) name for proper URI resolution
- New ID format: `phenopacket.store:{cohort}/{phenopacket_id}` (e.g., `phenopacket.store:POGZ/PMID_34133408_case`)
- Falls back to original format when cohort is not available
- Updates README with documentation of the entity ID format

Closes #6

## Test plan

- [x] Added `test_case_id_includes_cohort` to verify cohort is included in Case ID
- [x] Added `test_case_id_without_cohort` to verify fallback behavior works
- [x] All 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)