### PR TITLE
Bump actions/checkout from v4 to v5

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: b7f2804
+_commit: 1e35b56
 _src_path: gh:monarch-initiative/koza-ingest-template
 copyright_year: '2026'
 email: info@monarchinitiative.org

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Summary
- `copier update` to pick up checkout v4 → v5 in `test.yaml` from koza-ingest-template (PR #24).
- Also bumps the non-template `create-release.yaml` to match.

## Test plan
- [ ] CI passes